### PR TITLE
Modified opsim code to substitute '-' to '_' in hostname

### DIFF
--- a/bin/opsim.py
+++ b/bin/opsim.py
@@ -53,6 +53,7 @@ def getSessionID(lsstDB, sessionTbl, code_test, track_run, startup_comment):
         import socket
         host = socket.gethostname()
     host = host.split('.')[0]
+    host = host.replace('-', '_')
     user = os.getenv('USER')
     (yy, mm, dd, h, m, s, wday, yday, dst) = time.gmtime()
     date = '%d-%d-%d %02d:%02d:%02d' % (yy, mm, dd, h, m, s)

--- a/python/lsst/sims/operations/Proposal.py
+++ b/python/lsst/sims/operations/Proposal.py
@@ -84,6 +84,7 @@ Accessors
 - getFieldCoordinates
 """
 
+import os
 from math import *
 from utilities import *
 from LSSTObject import *
@@ -445,8 +446,11 @@ class Proposal(object):
             self.log.info('Proposal: getPropID()')
 
         # Get the short hostname
-        import socket
-        self.host = socket.gethostname().split('.', 1)[0]
+        self.host = os.getenv('OPSIM_HOSTNAME')
+        if self.host is None or self.host == "":
+            import socket
+            self.host = socket.gethostname().split('.', 1)[0]
+        self.host = self.host.replace('-', '_')
 
         # Get the object ID of self
         self.objID = id(self)


### PR DESCRIPTION
This was a blocker for me on our new UW machine (which is named astro-lsst-01). 
This is one potential fix -- to modify opsim so that it substitutes a slightly different hostname in the database records.

You could also try to fix all of the modifySchema -related scripts. I actually tried this first, but ran into some problems with the shell scripts. Also, it turned out that trying to select anything from the mysql database directly (from the summary_\* table) was kind of annoying as I kept forgetting to add the backticks in my selects.

It was not clear to me that you actually had to change the hostname in the Proposal table -- I suspect that field is perhaps redundant? But I did anyway for consistency.
