### PR TITLE
In move_data_output_obshistory.py: use sql inner join instead of loop

### DIFF
--- a/tools/schema_tools/move_data_output_obshistory.py
+++ b/tools/schema_tools/move_data_output_obshistory.py
@@ -19,32 +19,16 @@ def connect_db(hostname='localhost', username='www', passwdname='zxcvbnm', dbnam
     db.autocommit(True)
     return cursor
 
-def getDbData(cursor, sql):
-    global sessionID
-    # Fetch the data from the DB
-    ret = {}
-    n = cursor.execute(sql)
-    ret = cursor.fetchall()
-    return ret
-
-def insertDbData(cursor, sql):
-	global sessionID
-	cursor.execute(sql)
-
 def copy_data_over(hname, database, cursor, sessionID):
-	# print 'Copying data over'
+    # print 'Copying data over'
     sql = 'use %s' % (database)
-    ret = getDbData(cursor, sql)
-    sql = 'select obsHistID, fiveSigmaDepth, ditheredRA, ditheredDec from summary_%s_%d' % (hname, sessionID)
-    ret = getDbData(cursor, sql)
-
-    for k in range(len(ret)):
-	   obsHistID = ret[k][0]
-	   fiveSigmaDepth = ret[k][1]
-	   ditheredRA = ret[k][2]
-	   ditheredDec = ret[k][3]
-	   sql = 'update tObsHistory_%s_%d set fiveSigmaDepth=%f, ditheredRA=%f, ditheredDec=%f where obsHistID=%d' % (hname, sessionID, fiveSigmaDepth, ditheredRA, ditheredDec, obsHistID)
-	   insertDbData(cursor, sql)
+    newObsHist = 'tObsHistory_%s_%d' % (hname, sessionID)
+    summary = 'summary_%s_%d' % (hname, sessionID)
+    # Copy data from summary back to newObsHist 
+    # (note that records for same visit in summary can have multiple obsHistID's, but one will match tObsHistory table).
+    sql = 'update %s inner join %s using (obsHistID) set %s.fiveSigmaDepth=%s.fiveSigmaDepth,' % (newObsHist, summary, newObsHist, summary)
+    sql += ' %s.ditheredRA=%s.ditheredRA, %s.ditheredDec=%s.ditheredDec' % (newObsHist, summary, newObsHist, summary)
+    cursor.execute(sql)
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
New sql is faster and still accurate.

(new version)
[lynnej@astro-lsst-01 schema_tools]$ time python move_data_output_obshistory_new.py astro_lsst_01 OpsimDB 1008
0.090u 0.051s 1:20.88 0.1%  0+0k 1616+0io 5pf+0w

(old version)
[lynnej@astro-lsst-01 schema_tools]$ time python move_data_output_obshistory.py astro_lsst_01 OpsimDB 1008
77.389u 40.364s 6:19.16 31.0%   0+0k 0+0io 0pf+0w
