### PR TITLE
Modify obsScheduler to track expTime per proposal.

### DIFF
--- a/python/lsst/sims/operations/ObsScheduler.py
+++ b/python/lsst/sims/operations/ObsScheduler.py
@@ -473,12 +473,12 @@ class ObsScheduler(LSSTObject):
                     else:
                         if filter not in self.targetRank[fieldID]:
                             self.targetRank[fieldID][filter] = rank
-                            self.targetProps[fieldID][filter] = [propId]
+                            self.targetProps[fieldID][filter] = [propID]
                             self.targetXblk[fieldID][filter] = propIDforXblk
                             totPotentialTargets += 1
                         else:
                             self.targetRank[fieldID][filter] += rank
-                            self.targetProps[fieldID][filter].append(propId)
+                            self.targetProps[fieldID][filter].append(propID)
                             if propIDforXblk is not None:
                                 self.targetXblk[fieldID][filter] = propIDforXblk
 
@@ -508,11 +508,15 @@ class ObsScheduler(LSSTObject):
                 if rank <= 0.0:
                     continue
                 filter = key
-                # Choose the maximum exposure time for the proposals interested in this field/filter.
-                expTime = max([self.expTime[propID] for propID in self.targetProps[fieldID][key]])
+                propIDforXblk = self.targetXblk[fieldID][filter]
+                if propIDforXblk is None:
+                    # Choose the maximum exposure time for the proposals interested in this field/filter.
+                    expTime = max([self.expTime[propID] for propID in self.targetProps[fieldID][key]])
+                else:
+                    # Or if it was an exclusive block, use the proper exposure time for that proposal.
+                    expTime = self.expTime[propIDforXblk]
                 # And multiply by the exposure factor.
                 expTime *= self.filters.ExposureFactor[key]
-                propIDforXblk = self.targetXblk[fieldID][filter]
                 ra = self.targets[fieldID][0]
                 dec = self.targets[fieldID][1]
 

--- a/python/lsst/sims/operations/Proposal.py
+++ b/python/lsst/sims/operations/Proposal.py
@@ -741,14 +741,15 @@ class Proposal(object):
         self.last_observed_wasForThisProposal = False
 
         winner = None
-        # Find obs in self.winners
+        # Find obs in self.winners, count if exposure time was equal to or greater than desired exposure time.
         for o in self.winners:
             # if (o.fieldID == obs.fieldID and o.filter == obs.filter and o.exposureTime == obs.exposureTime):
             if (o.fieldID == obs.fieldID and o.filter == obs.filter):
-                winner = o
-                # print "Proposal: closeObs date=%d field=%d filter=%s propID=%d dist2moon=%f" %\
-                #       (obs.date, obs.fieldID, obs.filter, self.propID, o.distance2moon)
-                self.winners.remove(o)
+                if o.exposureTime <= obs.exposureTime:
+                    winner = o
+                    # print "Proposal: closeObs date=%d field=%d filter=%s propID=%d dist2moon=%f" %\
+                    #       (obs.date, obs.fieldID, obs.filter, self.propID, o.distance2moon)
+                    self.winners.remove(o)
                 break
         # If the observation was not found among the winners,
         # look for it in the losers set.
@@ -757,8 +758,9 @@ class Proposal(object):
                 # if o.fieldID == obs.fieldID and o.filter == obs.filter and
                 # o.exposureTime >= obs.exposureTime:
                 if o.fieldID == obs.fieldID and o.filter == obs.filter:
-                    winner = o
-                    self.loosers.remove(o)
+                    if o.exposureTime <= obs.exposureTime:
+                        winner = o
+                        self.loosers.remove(o)
                     break
             # if winner is not None:
             #     # It found it! Serendipitus


### PR DESCRIPTION
This does seem to enable the simulator to handle multiple exposure times per proposal. I did take an easy way out and just say that the exposure time used would be the maximum requested by any of the proposals.

I wasn't 100% sure what to do about the exclusive block stuff, but I think this works.
It might have been worthwhile to still set the exposure time to the max required for all proposals/exptimes, as currently proposals do not try to match exposure time when "closing" an observation -- they only look at fieldID and filter information. 
So - what I did was only let the proposals 'close' an observation as 'belonging' to them if the exposure time was equal to or longer than the exposure time they needed. Seems like a good compromise?
