### PR TITLE
Feature/add tools

### DIFF
--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -22,6 +22,7 @@ def convert_ecliptic(ra, dec):
     ecLon = ecLon % (2 * np.pi)
     return ecLat, ecLon
 
+
 def read_opsim(dbFileName):
     conn = sqlite3.connect(dbFileName)
     # Opsim angles are in radians.
@@ -33,7 +34,7 @@ def read_opsim(dbFileName):
     eclipLat, eclipLon = convert_ecliptic(df.fieldRA, df.fieldDec)
     df['eclipLat'] = eclipLat
     df['eclipLon'] = eclipLon
-        # Grab LSST longitude/latitude for ra/dec to alt/az conversion.
+    # Grab LSST longitude/latitude for ra/dec to alt/az conversion.
     telescope = Site('LSST')
     sunEclipLon = np.zeros(len(df))
     for i, row in df.iterrows():
@@ -43,6 +44,7 @@ def read_opsim(dbFileName):
         sunEclLat, sunEclipLon[i] = convert_ecliptic(sunRA[0], sunDec[0])
     df['sunEclipLon'] = sunEclipLon
     return df
+
 
 def add_skybright(df):
     skyModel = skybrightness.SkyModel(mags=True)
@@ -62,9 +64,10 @@ def add_skybright(df):
                            eclipLat=np.array([dfi.eclipLat]),
                            degrees=False)
         mags = skyModel.returnMags()
-        sims_skybright[j] = mags[dfi['filter']][0]
+        sims_skybright[i] = mags[dfi['filter']][0]
     df['sims_skybright'] = sims_skybright
     return sims_skybright
+
 
 def add_m5(df):
     m5 = np.zeros(len(df))
@@ -74,6 +77,7 @@ def add_m5(df):
                             df.visitExpTime.as_matrix()[match], df.airmass.as_matrix()[match])
     df['sims_m5'] = m5
     return df
+
 
 def write_opsim(df, dbFileName):
     # Could have written data back to sqlite using pandas, to_sql, but it's not clear if that would

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -10,6 +10,11 @@ import lsst.sims.skybrightness as skybrightness
 
 from opsimUtils import calc_m5
 
+import time
+def dtime(time_prev):
+    return (time.time() - time_prev, time.time())
+
+
 
 def convert_ecliptic(ra, dec):
     ecinc = np.radians(23.439291)
@@ -51,6 +56,7 @@ def read_opsim(dbFileName):
 def add_skybright(df):
     skyModel = skybrightness.SkyModel(mags=True)
     sims_skybright = np.zeros(len(df), float)
+    t = time.time()
     for i, dfi in df.iterrows():
         airmass = dfi.airmass
         alts = dfi.altitude
@@ -64,9 +70,11 @@ def add_skybright(df):
                            moonAz=dfi.moonAZ, sunAlt=dfi.sunAlt, sunAz=dfi.sunAz,
                            sunEclipLon=dfi.sunEclipLon, eclipLon=np.array([dfi.eclipLon]),
                            eclipLat=np.array([dfi.eclipLat]),
-                           degrees=False)
+                           degrees=False, filterNames=[dfi['filter']])
         mags = skyModel.returnMags()
         sims_skybright[i] = mags[dfi['filter']][0]
+    dt, t = dtime(t)
+    print('%f seconds to calculate %d skybrightnesses' % (dt, i))
     df['sims_skybright'] = sims_skybright
     return df
 

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -110,7 +110,8 @@ def write_opsim(df, dbFileName):
     conn.commit()
     # Find the session id, then add a comment about updating the sky brightness.
     query = 'select sessionID from Session'
-    res = cur.execute(query)
+    cur.execute(query)
+    res = cur.fetchall()
     sessionID = int(res[0])
     query = "insert into Config (moduleName, paramIndex, paramName, paramValue, comment, Session_sessionID, nonPropID) values"
     query += "('Comment', 1, 'SkyBrightness', 'sims_skybrightness', '', sessionID, '0');"

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -110,10 +110,11 @@ def write_opsim(df, dbFileName):
     conn.commit()
     # Find the session id, then add a comment about updating the sky brightness.
     query = 'select sessionID from Session'
-    res = cur.execute(query)
-    sessionID = int(res[0])
+    cur.execute(query)
+    res = cur.fetchall()
+    sessionID = int(res[0][0])
     query = "insert into Config (moduleName, paramIndex, paramName, paramValue, comment, Session_sessionID, nonPropID) values"
-    query += "('Comment', 1, 'SkyBrightness', 'sims_skybrightness', '', sessionID, '0');"
+    query += "('Comment', 1, 'SkyBrightness', 'sims_skybrightness', '', %s, '0');" % sessionID
     cur.execute(query)
     conn.commit()
     conn.close()

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -1,0 +1,113 @@
+from __future__ import print_function
+import sqlite3
+import numpy as np
+import pandas as pd
+
+from lsst.sims.utils import Site
+import lsst.sims.skybrightness as skybrightness
+
+from opsimUtils import calc_m5
+
+
+def convert_ecliptic(ra, dec):
+    ecinc = np.radians(23.439291)
+    x = np.cos(ra) * np.cos(dec)
+    y = np.sin(ra) * np.cos(dec)
+    z = np.sin(dec)
+    xp = x
+    yp = np.cos(ecinc) * y + np.sin(ecinc) * z
+    zp = -np.sin(ecinc) * y + np.cos(ecinc) * z
+    ecLat = np.arcsin(zp)
+    ecLon = np.arctan2(yp, xp)
+    ecLon = ecLon % (2 * np.pi)
+    return ecLat, ecLon
+
+def read_opsim(dbFileName):
+    conn = sqlite3.connect(dbFileName)
+    # Opsim angles are in radians.
+    query = "select obsHistID, fieldRA, fieldDec, altitude, azimuth, expMJD, filter, "
+    query += "visitExpTime, FWHMeff, airmass, moonPhase, moonAlt, moonAz, sunAlt, "
+    query += "sunAz from summary"
+    df = pd.read_sql_query(query, conn)
+    conn.close()
+    eclipLat, eclipLon = convert_ecliptic(df.fieldRA, df.fieldDec)
+    df['eclipLat'] = eclipLat
+    df['eclipLon'] = eclipLon
+        # Grab LSST longitude/latitude for ra/dec to alt/az conversion.
+    telescope = Site('LSST')
+    sunEclipLon = np.zeros(len(df))
+    for i, row in df.iterrows():
+        sunRA, sunDec = skybrightness.stupidFast_altAz2RaDec([row['sunAlt']], [row['sunAz']],
+                                                             telescope.latitude_rad,
+                                                             telescope.longitude_rad, row['expMJD'])
+        sunEclLat, sunEclipLon[i] = convert_ecliptic(sunRA[0], sunDec[0])
+    df['sunEclipLon'] = sunEclipLon
+    return df
+
+def add_skybright(df):
+    skyModel = skybrightness.SkyModel(mags=True)
+    sims_skybright = np.zeros(len(df), float)
+    for i, dfi in df.iterrows():
+        airmass = dfi.airmass
+        alts = dfi.altitude
+        # Fake the airmass if we're over the limit.
+        if airmass > skyModel.airmassLimit:
+            airmass = skyModel.airmassLimit - 0.1
+            alts = np.pi/2.-np.arccos(1./airmass)
+        skyModel.setParams(airmass=np.array([airmass]), azs=np.array([dfi.azimuth]),
+                           alts=np.array([alts]),
+                           moonPhase=dfi.moonPhase, moonAlt=dfi.moonAlt,
+                           moonAz=dfi.moonAZ, sunAlt=dfi.sunAlt, sunAz=dfi.sunAz,
+                           sunEclipLon=dfi.sunEclipLon, eclipLon=np.array([dfi.eclipLon]),
+                           eclipLat=np.array([dfi.eclipLat]),
+                           degrees=False)
+        mags = skyModel.returnMags()
+        sims_skybright[j] = mags[dfi['filter']][0]
+    df['sims_skybright'] = sims_skybright
+    return sims_skybright
+
+def add_m5(df):
+    m5 = np.zeros(len(df))
+    for f in df['filter'].unique():
+        match = np.where(df['filter'] == f)
+        m5[match] = calc_m5(f, df.sims_skybright.as_matrix()[match], df.FWHMeff.as_matrix()[match],
+                            df.visitExpTime.as_matrix()[match], df.airmass.as_matrix()[match])
+    df['sims_m5'] = m5
+    return df
+
+def write_opsim(df, dbFileName):
+    # Could have written data back to sqlite using pandas, to_sql, but it's not clear if that would
+    # let me insert just the additional columns.
+    conn = sqlite3.connect(dbFileName)
+    cur = conn.cursor()
+    # Add columns if they don't exist
+    try:
+        query = 'select sims_skybrightness from summary limit 1'
+        cur.execute(query)
+    except sqlite3.OperationalError:
+        query = 'alter table summary add column "sims_skybrightness" real'
+        cur.execute(query)
+    try:
+        query = 'select sims_m5 from summary limit 1'
+        cur.execute(query)
+    except sqlite3.OperationalError:
+        query = 'alter table summary add column "sims_m5" real'
+        cur.execute(query)
+    # Populate columns.
+    for i, row in df.iterrows():
+        query = 'update summary set sims_skybrightness = %f, sims_m5 = %f ' \
+                'where obsHistID = %d' % (row.sims_skybright, row.sims_m5, row.obsHistID)
+        cur.execute(query)
+    conn.close()
+
+
+if __name__ == '__main__':
+    dbFile = '/Users/lynnej/opsim/db/minion_1016_sqlite.db'
+    print('Reading data')
+    df = read_opsim(dbFile)
+    print('Adding skybrightness')
+    df = add_skybright(df)
+    print('Adding new m5')
+    df = add_m5(df)
+    print('Saving to disk')
+    write_opsim(df, dbFile)

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -66,7 +66,7 @@ def add_skybright(df):
         mags = skyModel.returnMags()
         sims_skybright[i] = mags[dfi['filter']][0]
     df['sims_skybright'] = sims_skybright
-    return sims_skybright
+    return df
 
 
 def add_m5(df):

--- a/tools/addSimsSkybrightness.py
+++ b/tools/addSimsSkybrightness.py
@@ -108,6 +108,14 @@ def write_opsim(df, dbFileName):
                 'where obsHistID = %d' % (row.sims_skybright, row.sims_m5, row.obsHistID)
         cur.execute(query)
     conn.commit()
+    # Find the session id, then add a comment about updating the sky brightness.
+    query = 'select sessionID from Session'
+    res = cur.execute(query)
+    sessionID = int(res[0])
+    query = "insert into Config (moduleName, paramIndex, paramName, paramValue, comment, Session_sessionID, nonPropID) values"
+    query += "('Comment', 1, 'SkyBrightness', 'sims_skybrightness', '', sessionID, '0');"
+    cur.execute(query)
+    conn.commit()
     conn.close()
 
 

--- a/tools/calcMinAirmass.py
+++ b/tools/calcMinAirmass.py
@@ -17,8 +17,8 @@ plus_1hr = np.arccos(np.cos(min_z) * np.cos(ha_offset))
 ha_offset = np.radians(30)
 plus_2hr = np.arccos(np.cos(min_z) * np.cos(ha_offset))
 
-airmass_1hr = 1/ np.cos(plus_1hr)
-airmass_2hr = 1./np.cos(plus_2hr)
+airmass_1hr = 1. / np.cos(plus_1hr)
+airmass_2hr = 1. / np.cos(plus_2hr)
 
 plt.plot(field_dec, min_airmass, 'k-', label='zenith')
 plt.plot(field_dec, airmass_1hr, 'r:', label='+1hr')

--- a/tools/calcMinAirmass.py
+++ b/tools/calcMinAirmass.py
@@ -1,0 +1,34 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+tele_lat = -29.666667
+
+dec_min = np.max([tele_lat-90, -90])
+dec_max = np.min([tele_lat+90, 90])
+field_dec = np.arange(dec_min, dec_max, 0.25)
+
+min_z = np.radians(np.abs(field_dec - tele_lat))
+min_airmass = 1 / np.cos(min_z)
+
+# Add expected airmass for +/- 1 & 2 hours around meridian
+# cos z  =cos(min_z) * cos(ha_offset)
+ha_offset = np.radians(15)
+plus_1hr = np.arccos(np.cos(min_z) * np.cos(ha_offset))
+ha_offset = np.radians(30)
+plus_2hr = np.arccos(np.cos(min_z) * np.cos(ha_offset))
+
+airmass_1hr = 1/ np.cos(plus_1hr)
+airmass_2hr = 1./np.cos(plus_2hr)
+
+plt.plot(field_dec, min_airmass, 'k-', label='zenith')
+plt.plot(field_dec, airmass_1hr, 'r:', label='+1hr')
+plt.plot(field_dec, airmass_2hr, 'g:', label='+2hr')
+plt.legend(loc='upper right', fancybox=True, fontsize='small')
+plt.xlabel('Field Dec')
+plt.ylabel('Min airmass')
+plt.ylim(1, 3)
+plt.grid(True)
+
+
+plt.show()
+

--- a/tools/convert_old_runs.py
+++ b/tools/convert_old_runs.py
@@ -1,0 +1,106 @@
+import os
+import numpy as np
+import pandas as pd
+from sqlalchemy import create_engine
+
+# Convert at least some older run sqlite outputs into new format sqlite outputs (for MAF)
+
+
+def calc_m5(visitFilter, filtsky, seeing, expTime, airmass, tauCloud):
+    # Set up expected extinction (kAtm) and m5 normalization values (Cm) for each filter.
+    # The Cm values must be changed when telescope and site parameters are updated.
+    Cm = {'u':23.60,
+          'g':24.57,
+          'r':24.57,
+          'i':24.47,
+          'z':24.19,
+          'y':23.45,
+          'y1':23.74}
+    kAtm = {'u':0.48,
+            'g':0.21,
+            'r':0.10,
+            'i':0.07,
+            'z':0.06,
+            'y':0.06,
+            'y1':0.11}
+    tauCloud = 0.;
+    # Using Kem's SkyBrightness
+    m5 = (Cm[visitFilter] + 0.50*(filtsky-21) + 2.5*np.log10(0.7/seeing) +
+          1.25*np.log10(expTime/30) - kAtm[visitFilter]*(airmass-1) + 1.1*tauCloud)
+    return m5
+
+def calc_night(expMJD, minexpMJD):
+    local_midnight = 0.16
+    const = minexpMJD + local_midnight - 0.5
+    night = np.floor(expMJD - const)
+    return night
+
+def read_data(filename):
+    data = pd.read_table(filename)
+    return data
+
+def convert_cols(data):
+    cols_need = ['obsHistID', 'sessionID', 'propID', 'fieldID', 'fieldRA', 'fieldDec', 'filter',
+                 'expDate', 'expMJD', 'night', 'visitTime', 'visitExpTime', 'finRank', 'finSeeing',
+                 'transparency', 'airmass', 'vSkyBright', 'filtSkyBrightness', 'rotSkyPos', 'rotTelPos',
+                 'lst', 'altitude', 'azimuth', 'dist2Moon', 'solarElong',
+                 'moonRA', 'moonDec', 'moonAlt', 'moonAZ', 'moonPhase', 'sunAlt', 'sunAz', 'phaseAngle',
+                 'rScatter', 'mieScatter', 'moonIllum', 'moonBright', 'darkBright', 'rawSeeing', 'wind',
+                 'humidity', 'slewDist', 'slewTime', 'fiveSigmaDepth', 'ditheredRA', 'ditheredDec']
+    cols_have = []
+    for k in data:
+        cols_have.append(k)
+    cols_map = {'ditheredRA':'hexdithra', 'ditheredDec':'hexdithdec', 'visitTime':'expTime',
+                'vSkyBright':'VskyBright', 'filtSkyBrightness':'filtSky', 'finSeeing':'seeing',
+                'transparency':'xparency' }
+    cols_map_backup = {'ditheredRA':-99, 'ditheredDec':-99}
+    cols_default = {'visitExpTime':30.0, 'solarElong':-99, 'wind':-99, 'humidity':-99, 'moonAZ':-99}
+    cols_calc = {'fiveSigmaDepth':calc_m5, 'night':calc_night}
+
+    print "Needed but not present or translated."
+    for c in cols_need:
+        if c not in cols_have and c not in cols_default and c not in cols_calc:
+            if c in cols_map:
+                if cols_map[c] not in cols_have:
+                    if c not in cols_map_backup:
+                        print c
+            else:
+                print c
+    print "Present, but not in needed list. "
+    for k in cols_have:
+        if k not in cols_need:
+            print k
+
+    nvisits = len(data)
+    data2 = {}
+    for c in cols_need:
+        if c in cols_have:
+            data2[c] = data[c]
+        elif c in cols_map:
+            if cols_map[c] not in data and c in cols_map_backup:
+                data2[c] = np.ones(nvisits,float) * cols_map_backup[c]
+            else:
+                data2[c] = data[cols_map[c]]
+        elif c in cols_default:
+            data2[c] = np.ones(nvisits, float) * cols_default[c]
+        elif c in cols_calc:
+            if c == 'fiveSigmaDepth':
+                data2[c] = np.zeros(nvisits, float)
+                for index, v in data.iterrows():
+                    data2[c][index] = calc_m5(v['filter'], v['filtSky'], v['seeing'],
+                                          v['expTime']-4.0, v['airmass'], 0.0)
+            elif c == 'night':
+                data2[c] = calc_night(data['expMJD'], int(data['expMJD'].min()))
+    data2 = pd.DataFrame(data2)
+    return data2
+
+
+if __name__ == '__main__':
+    #data = read_data('opsim3_61_output.dat')
+    data = read_data('opsim2_168_output.dat')
+    data2 = convert_cols(data)
+    print data2.keys()
+    #engine = create_engine('sqlite:///opsim3_61_sqlite.db')
+    engine = create_engine('sqlite:///opsim2_168_sqlite.db')
+    data2.to_sql('summary', engine, index=False)
+    

--- a/tools/opsimUtils.py
+++ b/tools/opsimUtils.py
@@ -7,19 +7,19 @@ def calc_m5(visitFilter, filtsky, FWHMeff, expTime, airmass, tauCloud=0):
     # The Cm values must be changed when telescope and site parameters are updated.
     #
     # These values are calculated using $SYSENG_THROUGHPUTS/python/calcM5.py.
-    # This set of values are calculated using v1.0 of the SYSENG_THROUGHPUTS repo.
-    Cm = {'u': 22.94,
-          'g': 24.46,
-          'r': 24.48,
-          'i': 24.34,
-          'z': 24.18,
-          'y': 23.73}
-    dCm_infinity = {'u': 0.56,
-                    'g': 0.12,
-                    'r': 0.06,
-                    'i': 0.05,
-                    'z': 0.03,
-                    'y': 0.02}
+    # This set of values are calculated using v1.2 of the SYSENG_THROUGHPUTS repo.
+    Cm = {'u': 22.74,
+          'g': 24.38,
+          'r': 24.43,
+          'i': 24.30,
+          'z': 24.15,
+          'y': 23.70}
+    dCm_infinity = {'u': 0.75,
+                    'g': 0.19,
+                    'r': 0.10,
+                    'i': 0.07,
+                    'z': 0.05,
+                    'y': 0.04}
     kAtm = {'u': 0.50,
             'g': 0.21,
             'r': 0.13,

--- a/tools/opsimUtils.py
+++ b/tools/opsimUtils.py
@@ -8,30 +8,30 @@ def calc_m5(visitFilter, filtsky, FWHMeff, expTime, airmass, tauCloud=0):
     #
     # These values are calculated using $SYSENG_THROUGHPUTS/python/calcM5.py.
     # This set of values are calculated using v1.0 of the SYSENG_THROUGHPUTS repo.
-    Cm = {'u':22.94,
-          'g':24.46,
-          'r':24.48,
-          'i':24.34,
-          'z':24.18,
-          'y':23.73}
-    dCm_infinity = {'u':0.56,
-                    'g':0.12,
-                    'r':0.06,
-                    'i':0.05,
-                    'z':0.03,
-                    'y':0.02}
-    kAtm = {'u':0.50,
-            'g':0.21,
-            'r':0.13,
-            'i':0.10,
-            'z':0.07,
-            'y':0.18}
-    msky = {'u':22.95,
-            'g':22.24,
-            'r':21.20,
-            'i':20.47,
-            'z':19.60,
-            'y':18.63}
+    Cm = {'u': 22.94,
+          'g': 24.46,
+          'r': 24.48,
+          'i': 24.34,
+          'z': 24.18,
+          'y': 23.73}
+    dCm_infinity = {'u': 0.56,
+                    'g': 0.12,
+                    'r': 0.06,
+                    'i': 0.05,
+                    'z': 0.03,
+                    'y': 0.02}
+    kAtm = {'u': 0.50,
+            'g': 0.21,
+            'r': 0.13,
+            'i': 0.10,
+            'z': 0.07,
+            'y': 0.18}
+    msky = {'u': 22.95,
+            'g': 22.24,
+            'r': 21.20,
+            'i': 20.47,
+            'z': 19.60,
+            'y': 18.63}
     # Calculate adjustment if readnoise is significant for exposure time
     # (see overview paper, equation 7)
     Tscale = expTime / 30.0 * np.power(10.0, -0.4*(filtsky - msky[visitFilter]))
@@ -40,6 +40,7 @@ def calc_m5(visitFilter, filtsky, FWHMeff, expTime, airmass, tauCloud=0):
     m5 = (Cm[visitFilter] + dCm + 0.50*(filtsky-21.0) + 2.5*np.log10(0.7/FWHMeff) +
           1.25*np.log10(expTime/30.0) - kAtm[visitFilter]*(airmass-1.0) + 1.1*tauCloud)
     return m5
+
 
 def calc_FWHMeff(visitFilter, rawSeeing, airmass):
     """Convert the raw seeing from the seeing database into FWHMeff for a particular observation."""

--- a/tools/opsimUtils.py
+++ b/tools/opsimUtils.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+
+def calc_m5(visitFilter, filtsky, FWHMeff, expTime, airmass, tauCloud=0):
+    """Calculate the m5 value, using opsim methods."""
+    # Set up expected extinction (kAtm) and m5 normalization values (Cm) for each filter.
+    # The Cm values must be changed when telescope and site parameters are updated.
+    #
+    # These values are calculated using $SYSENG_THROUGHPUTS/python/calcM5.py.
+    # This set of values are calculated using v1.0 of the SYSENG_THROUGHPUTS repo.
+    Cm = {'u':22.94,
+          'g':24.46,
+          'r':24.48,
+          'i':24.34,
+          'z':24.18,
+          'y':23.73}
+    dCm_infinity = {'u':0.56,
+                    'g':0.12,
+                    'r':0.06,
+                    'i':0.05,
+                    'z':0.03,
+                    'y':0.02}
+    kAtm = {'u':0.50,
+            'g':0.21,
+            'r':0.13,
+            'i':0.10,
+            'z':0.07,
+            'y':0.18}
+    msky = {'u':22.95,
+            'g':22.24,
+            'r':21.20,
+            'i':20.47,
+            'z':19.60,
+            'y':18.63}
+    # Calculate adjustment if readnoise is significant for exposure time
+    # (see overview paper, equation 7)
+    Tscale = expTime / 30.0 * np.power(10.0, -0.4*(filtsky - msky[visitFilter]))
+    dCm = dCm_infinity[visitFilter] - 1.25*np.log10(1 + (10**(0.8*dCm_infinity[visitFilter]) - 1)/Tscale)
+    # Calculate fiducial m5
+    m5 = (Cm[visitFilter] + dCm + 0.50*(filtsky-21.0) + 2.5*np.log10(0.7/FWHMeff) +
+          1.25*np.log10(expTime/30.0) - kAtm[visitFilter]*(airmass-1.0) + 1.1*tauCloud)
+    return m5
+
+def calc_FWHMeff(visitFilter, rawSeeing, airmass):
+    """Convert the raw seeing from the seeing database into FWHMeff for a particular observation."""
+    filterWave = {'u': 367.0, 'g': 482.5, 'r': 622.2, 'i': 754.5, 'z': 869.1, 'y': 971.0}
+    telSeeing = 0.25
+    opticalDesign = 0.08
+    cameraSeeing = 0.30
+    fwhm_sys = np.sqrt(telSeeing**2 + opticalDesign**2 + cameraSeeing**2) * np.power(airmass, 0.6)
+    fwhm_atm = rawSeeing * np.power(500.0 / filterWave[visitFilter], 0.3) * np.power(airmass, 0.6)
+    fwhmEff = 1.16 * np.sqrt(fwhm_sys**2 + 1.04*fwhm_atm**2)
+    return fwhmEff

--- a/tools/schema_tools/dropSubsetTables.sh
+++ b/tools/schema_tools/dropSubsetTables.sh
@@ -27,4 +27,5 @@ $mysqlcmd -e "drop table if exists $1.tSlewState_$2_$3"
 $mysqlcmd -e "drop table if exists $1.tSlewMaxSpeeds_$2_$3"
 
 # Removing dat files
-/bin/rm *_$2_$3.dat Cloud.dat Seeing.dat Field.dat
+/bin/rm *_$2_$3.dat 
+#/bin/rm Cloud.dat Seeing.dat Field.dat


### PR DESCRIPTION
This just added a few additional tools - a way to update the output of opsim with the sims_skybrightness values (and resulting m5), instead of the standard opsim skybrightness (although it currently goes into the same column). Adds opsimutils, which adds a simple place to import m5 and fwhm_eff calculations from. Adds convert_old_runs script, which converts things like opsim3_61 into the new format (and adds appropriate new /extra columns as needed). 