### PR TITLE
remove 'lsst' from table file

### DIFF
--- a/ups/sims_operations.table
+++ b/ups/sims_operations.table
@@ -5,7 +5,8 @@
 # included by low-level LSST packages such as utils or daf_base.
 # Any other package whose interface is used should be listed explicitly
 # rather than assuming it will be included recursively.
-setupRequired(lsst)
+setupRequired(scons)
+setupRequired(sconsUtils)
 setupRequired(mariadb)
 setupRequired(mysqlpython)
 setupRequired(palpy)


### PR DESCRIPTION
apparently, including lsst in the table file has been
a deprecated practice for some time

add scons to list of required packages

add sconsUtils to list of required packages